### PR TITLE
Add check to avoid pathname from crashing build

### DIFF
--- a/package.py
+++ b/package.py
@@ -99,7 +99,7 @@ def copy_dependencies_from_local():
   for dep_pkg_name in DEPENDENCIES_LOCAL:
     dirpaths = (
       glob.glob(f'/usr/lib/python3.*/site-packages/{dep_pkg_name}*')
-      + glob.glob(f'{os.environ["HOME"]}/.local/lib/python3.*/site-packages/{dep_pkg_name}*'))
+      + glob.glob(f'{os.environ["HOME"]}/.local/lib/python3.*/site-packages/{dep_pkg_name}*[0-9]*'))
     if len(dirpaths) > 1:
       dirpaths.sort(key=lambda p: _path_to_sort_tuple(p))
     dirpath = dirpaths[-1]


### PR DESCRIPTION
The string paths fed to dirpaths.sort( _path_to_sort_tuple()) 
eventually get fed 
into _extract_version() which will kill the build process if its inputs
do not contain numbers.